### PR TITLE
test(server): Raise coverage for security and server handlers

### DIFF
--- a/app/components/overlays/Comment.vue
+++ b/app/components/overlays/Comment.vue
@@ -5,7 +5,7 @@ const comment = ref(props.initialValue)
 const isDirty = computed(() => comment.value !== props.initialValue)
 
 const emit = defineEmits<{
-	(event: 'close', payload: { value: string }): void
+	(_event: 'close', _payload: { value: string }): void
 }>()
 
 function handleClose() {

--- a/app/components/overlays/Suggestion.vue
+++ b/app/components/overlays/Suggestion.vue
@@ -22,7 +22,7 @@ const {
 } = useTurnstile()
 
 const emit = defineEmits<{
-	(e: 'close'): void
+	(_e: 'close'): void
 }>()
 
 const state = reactive<Submission>({

--- a/app/components/overlays/Welcome.vue
+++ b/app/components/overlays/Welcome.vue
@@ -4,7 +4,7 @@ import type { ViewMode } from '~~/shared/types/primitives'
 const state = useStateStore()
 
 const emit = defineEmits<{
-	(e: 'close'): void
+	(_e: 'close'): void
 }>()
 
 function handleSelect(value: ViewMode) {

--- a/app/components/report/ReportGenerationFlow.vue
+++ b/app/components/report/ReportGenerationFlow.vue
@@ -37,7 +37,7 @@ type ReportGenerationFlowProps = {
 const props = defineProps<ReportGenerationFlowProps>()
 
 const emit = defineEmits<{
-	(e: 'close'): void
+	(_e: 'close'): void
 }>()
 
 const form = useTemplateRef('form')

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,23 @@ import withNuxt from './.nuxt/eslint.config.mjs'
 export default withNuxt(
 	{
 		rules: {
-			'vue/multi-word-component-names': 'off'
+			'vue/multi-word-component-names': 'off',
+			'no-unused-vars': [
+				'error',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					caughtErrorsIgnorePattern: '^_'
+				}
+			],
+			'@typescript-eslint/no-unused-vars': [
+				'error',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					caughtErrorsIgnorePattern: '^_'
+				}
+			]
 		}
 	},
 

--- a/tests/unit/server/api/content-collections.get.test.ts
+++ b/tests/unit/server/api/content-collections.get.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+
+async function loadCollectionRoute(modulePath: string, event: Record<string, unknown> = {}) {
+	vi.resetModules()
+
+	vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
+
+	const allMock = vi.fn().mockResolvedValue([{ id: 'item-1' }])
+	const whereMock = vi.fn().mockReturnValue({ all: allMock })
+	const queryCollectionMock = vi.fn().mockReturnValue({ where: whereMock })
+
+	vi.doMock('@nuxt/content/server', () => ({
+		queryCollection: queryCollectionMock
+	}))
+
+	const module = await import(modulePath)
+	return {
+		handler: module.default as (_input: unknown) => Promise<unknown>,
+		event,
+		queryCollectionMock,
+		whereMock,
+		allMock
+	}
+}
+
+describe('server/api content collection handlers', () => {
+	it('queries markdown prompts from _prompts collection', async () => {
+		const { handler, event, queryCollectionMock, whereMock, allMock } =
+			await loadCollectionRoute('~~/server/api/_prompts.get')
+
+		await expect(handler(event)).resolves.toEqual([{ id: 'item-1' }])
+		expect(queryCollectionMock).toHaveBeenCalledWith(event, '_prompts')
+		expect(whereMock).toHaveBeenCalledWith('extension', '=', 'md')
+		expect(allMock).toHaveBeenCalledTimes(1)
+	})
+
+	it('queries markdown items from items collection', async () => {
+		const { handler, event, queryCollectionMock, whereMock, allMock } =
+			await loadCollectionRoute('~~/server/api/content.get')
+
+		await expect(handler(event)).resolves.toEqual([{ id: 'item-1' }])
+		expect(queryCollectionMock).toHaveBeenCalledWith(event, 'items')
+		expect(whereMock).toHaveBeenCalledWith('extension', '=', 'md')
+		expect(allMock).toHaveBeenCalledTimes(1)
+	})
+
+	it('queries markdown extras from extras collection', async () => {
+		const { handler, event, queryCollectionMock, whereMock, allMock } =
+			await loadCollectionRoute('~~/server/api/extras.get')
+
+		await expect(handler(event)).resolves.toEqual([{ id: 'item-1' }])
+		expect(queryCollectionMock).toHaveBeenCalledWith(event, 'extras')
+		expect(whereMock).toHaveBeenCalledWith('extension', '=', 'md')
+		expect(allMock).toHaveBeenCalledTimes(1)
+	})
+})

--- a/tests/unit/server/api/datahub-submission.post.test.ts
+++ b/tests/unit/server/api/datahub-submission.post.test.ts
@@ -90,6 +90,31 @@ describe('POST /api/datahub/submission', () => {
 		})
 	})
 
+	it('throws when runtime config misses DATAHUB_TOKEN', async () => {
+		vi.stubGlobal(
+			'readBody',
+			vi.fn().mockResolvedValue({
+				title: 'Nieuwe suggestie',
+				description: 'Korte beschrijving',
+				body: 'Lange toelichting',
+				category: 'extra',
+				goals: ['Informeren'],
+				exampleUrl: 'https://example.com'
+			})
+		)
+		vi.stubGlobal(
+			'useRuntimeConfig',
+			vi.fn().mockReturnValue({ datahub: { url: 'https://datahub.example', token: '   ' } })
+		)
+		vi.stubGlobal('$fetch', vi.fn())
+
+		const { handler } = await loadHandler()
+		await expect(handler({})).rejects.toMatchObject({
+			statusCode: 500,
+			statusMessage: 'DATAHUB_TOKEN is missing in runtimeConfig'
+		})
+	})
+
 	it('throws on invalid request payload before calling downstream API', async () => {
 		const fetchSpy = vi.fn()
 		vi.stubGlobal('readBody', vi.fn().mockResolvedValue({ title: '' }))

--- a/tests/unit/server/api/sentry-test.get.test.ts
+++ b/tests/unit/server/api/sentry-test.get.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+
+async function loadSentryTestRoute() {
+	vi.resetModules()
+	vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
+	const module = await import('~~/server/api/_sentry/test.get')
+	return {
+		handler: module.default as () => never
+	}
+}
+
+describe('GET /api/_sentry/test', () => {
+	it('throws the intentional sentry test error', async () => {
+		const { handler } = await loadSentryTestRoute()
+		expect(() => handler()).toThrowError('Sentry test API route error')
+	})
+})

--- a/tests/unit/server/middleware/route-guard.test.ts
+++ b/tests/unit/server/middleware/route-guard.test.ts
@@ -92,4 +92,25 @@ describe('server/middleware/route-guard', () => {
 			refererHeader: 'https://evil.example.com/path'
 		})
 	})
+
+	it('allows protected POST request when origin checks pass', async () => {
+		const { handler, evaluateProtectedPostRequestMock } = await loadRouteGuard({
+			isAdmin: false,
+			decision: { allowed: true },
+			url: 'https://app.example.com/api/ai/briefing',
+			headers: {
+				'sec-fetch-site': 'same-origin',
+				origin: 'https://app.example.com'
+			}
+		})
+
+		expect(() => handler({ node: { req: { method: 'POST' } } } as never)).not.toThrow()
+		expect(evaluateProtectedPostRequestMock).toHaveBeenCalledWith({
+			pathname: '/api/ai/briefing',
+			requestOrigin: 'https://app.example.com',
+			fetchSiteHeader: 'same-origin',
+			originHeader: 'https://app.example.com',
+			refererHeader: undefined
+		})
+	})
 })

--- a/tests/unit/server/plugins/sentry-cloudflare-plugin.test.ts
+++ b/tests/unit/server/plugins/sentry-cloudflare-plugin.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+
+async function loadSentryCloudflarePlugin() {
+	vi.resetModules()
+
+	const zodErrorsIntegrationMock = vi.fn(() => ({ name: 'zod-errors-integration' }))
+	const sentryCloudflareNitroPluginMock = vi.fn(
+		(factory: () => Record<string, unknown>) => factory
+	)
+	const defineNitroPluginMock = vi.fn((plugin: unknown) => plugin)
+	const useRuntimeConfigMock = vi.fn(() => ({
+		public: {
+			sentry: {
+				dsn: 'https://dsn.example/123',
+				release: '1.2.3',
+				environment: 'production'
+			},
+			mode: {
+				isDebug: false
+			}
+		}
+	}))
+
+	vi.stubGlobal('defineNitroPlugin', defineNitroPluginMock)
+	vi.stubGlobal('useRuntimeConfig', useRuntimeConfigMock)
+	vi.doMock('@sentry/nuxt', () => ({
+		zodErrorsIntegration: zodErrorsIntegrationMock
+	}))
+	vi.doMock('@sentry/nuxt/module/plugins', () => ({
+		sentryCloudflareNitroPlugin: sentryCloudflareNitroPluginMock
+	}))
+
+	const module = await import('~~/server/plugins/sentry-cloudflare-plugin')
+	return {
+		pluginFactory: module.default as () => Record<string, unknown>,
+		zodErrorsIntegrationMock,
+		sentryCloudflareNitroPluginMock,
+		defineNitroPluginMock,
+		useRuntimeConfigMock
+	}
+}
+
+describe('server/plugins/sentry-cloudflare-plugin', () => {
+	it('builds sentry cloudflare nitro plugin config from runtime settings', async () => {
+		const {
+			pluginFactory,
+			zodErrorsIntegrationMock,
+			sentryCloudflareNitroPluginMock,
+			defineNitroPluginMock,
+			useRuntimeConfigMock
+		} = await loadSentryCloudflarePlugin()
+
+		const config = pluginFactory()
+
+		expect(defineNitroPluginMock).toHaveBeenCalledTimes(1)
+		expect(sentryCloudflareNitroPluginMock).toHaveBeenCalledTimes(1)
+		expect(useRuntimeConfigMock).toHaveBeenCalledTimes(1)
+		expect(zodErrorsIntegrationMock).toHaveBeenCalledTimes(1)
+		expect(config).toEqual({
+			dsn: 'https://dsn.example/123',
+			release: '1.2.3',
+			environment: 'production',
+			debug: false,
+			sampleRate: 1,
+			tracesSampleRate: 1,
+			integrations: [{ name: 'zod-errors-integration' }]
+		})
+	})
+})

--- a/tests/unit/server/routes/assets/pathname.get.test.ts
+++ b/tests/unit/server/routes/assets/pathname.get.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+
+async function loadAssetsRoute(pathname?: string) {
+	vi.resetModules()
+
+	const createErrorMock = vi.fn((input: { statusCode: number; statusMessage: string }) => {
+		const error = new Error(input.statusMessage) as Error & {
+			statusCode?: number
+			statusMessage?: string
+		}
+		error.statusCode = input.statusCode
+		error.statusMessage = input.statusMessage
+		return error
+	})
+	const eventHandlerMock = vi.fn((handler: unknown) => handler)
+	const getRouterParamMock = vi.fn(() => pathname)
+	const serveMock = vi.fn().mockResolvedValue({ ok: true })
+	const setHeaderMock = vi.fn()
+
+	vi.stubGlobal('setHeader', setHeaderMock)
+	vi.doMock('h3', () => ({
+		createError: createErrorMock,
+		eventHandler: eventHandlerMock,
+		getRouterParam: getRouterParamMock
+	}))
+	vi.doMock('hub:blob', () => ({
+		blob: {
+			serve: serveMock
+		}
+	}))
+
+	const module = await import('~~/server/routes/assets/[...pathname].get')
+	return {
+		handler: module.default as (_event: unknown) => Promise<unknown>,
+		createErrorMock,
+		getRouterParamMock,
+		serveMock,
+		setHeaderMock
+	}
+}
+
+describe('GET /assets/[...pathname]', () => {
+	it('throws 404 when pathname is missing', async () => {
+		const { handler, serveMock, setHeaderMock } = await loadAssetsRoute(undefined)
+
+		await expect(handler({})).rejects.toMatchObject({
+			statusCode: 404,
+			statusMessage: 'Not Found'
+		})
+		expect(setHeaderMock).not.toHaveBeenCalled()
+		expect(serveMock).not.toHaveBeenCalled()
+	})
+
+	it('sets csp header and serves blob from assets prefix', async () => {
+		const { handler, serveMock, setHeaderMock, getRouterParamMock } =
+			await loadAssetsRoute('images/logo.svg')
+		const event = { id: 'event-1' }
+
+		await expect(handler(event)).resolves.toEqual({ ok: true })
+		expect(getRouterParamMock).toHaveBeenCalledWith(event, 'pathname')
+		expect(setHeaderMock).toHaveBeenCalledWith(
+			event,
+			'Content-Security-Policy',
+			"default-src 'none';"
+		)
+		expect(serveMock).toHaveBeenCalledWith(event, '/assets/images/logo.svg')
+	})
+})

--- a/tests/unit/server/utils/observability/timing.test.ts
+++ b/tests/unit/server/utils/observability/timing.test.ts
@@ -1,0 +1,120 @@
+import { createServerExecutionTimer } from '~~/server/utils/observability/timing'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('utils/observability/timing', () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('logs mark steps and done payload with merged metadata', () => {
+		const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+		vi.spyOn(Date, 'now')
+			.mockReturnValueOnce(1000)
+			.mockReturnValueOnce(1010)
+			.mockReturnValueOnce(1035)
+			.mockReturnValueOnce(1100)
+
+		const timer = createServerExecutionTimer('api/test')
+		timer.mark('parsed')
+		timer.mark('validated', { retries: 1 })
+		timer.done({ success: true })
+
+		expect(infoSpy).toHaveBeenNthCalledWith(1, '[timing] api/test :: parsed +10ms')
+		expect(infoSpy).toHaveBeenNthCalledWith(2, '[timing] api/test :: validated +25ms', {
+			retries: 1
+		})
+		expect(infoSpy).toHaveBeenNthCalledWith(3, '[timing] api/test :: done 100ms', {
+			totalMs: 100,
+			steps: [
+				{ step: 'parsed', durationMs: 10 },
+				{ step: 'validated', durationMs: 25 }
+			],
+			success: true
+		})
+	})
+
+	it('logs done payload without extra metadata', () => {
+		const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+		vi.spyOn(Date, 'now').mockReturnValueOnce(5000).mockReturnValueOnce(5030)
+
+		const timer = createServerExecutionTimer('api/done')
+		timer.done()
+
+		expect(infoSpy).toHaveBeenCalledWith('[timing] api/done :: done 30ms', {
+			totalMs: 30,
+			steps: []
+		})
+	})
+
+	it('normalizes Error objects with status fields in failure logs', () => {
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+		const timer = createServerExecutionTimer('api/fail')
+
+		const error = Object.assign(new Error('upstream failed'), {
+			statusCode: 502,
+			statusMessage: 'Bad Gateway'
+		})
+		timer.fail(error, { stage: 'verify' })
+
+		expect(errorSpy).toHaveBeenCalledTimes(1)
+		const [message, payload] = errorSpy.mock.calls[0] as [string, Record<string, unknown>]
+		expect(message).toMatch(/^\[timing\] api\/fail :: failed \d+ms$/)
+		expect(payload).toMatchObject({
+			steps: [],
+			error: {
+				name: 'Error',
+				message: 'upstream failed',
+				statusCode: 502,
+				statusMessage: 'Bad Gateway'
+			},
+			stage: 'verify'
+		})
+		expect(typeof payload.totalMs).toBe('number')
+	})
+
+	it('normalizes non-Error object failures', () => {
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+		vi.spyOn(Date, 'now').mockReturnValueOnce(3000).mockReturnValueOnce(3010)
+
+		const timer = createServerExecutionTimer('api/object-fail')
+		timer.fail({ reason: 'timeout', retryable: true })
+
+		expect(errorSpy).toHaveBeenCalledWith('[timing] api/object-fail :: failed 10ms', {
+			totalMs: 10,
+			steps: [],
+			error: { reason: 'timeout', retryable: true }
+		})
+	})
+
+	it('normalizes Error failures without status fields', () => {
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+		vi.spyOn(Date, 'now').mockReturnValueOnce(3500).mockReturnValueOnce(3501)
+
+		const timer = createServerExecutionTimer('api/error-no-status')
+		timer.fail(new Error('plain error'))
+
+		expect(errorSpy).toHaveBeenCalledWith('[timing] api/error-no-status :: failed 1ms', {
+			totalMs: 1,
+			steps: [],
+			error: {
+				name: 'Error',
+				message: 'plain error'
+			}
+		})
+	})
+
+	it('normalizes primitive failures into string values', () => {
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+		vi.spyOn(Date, 'now').mockReturnValueOnce(4000).mockReturnValueOnce(4015)
+
+		const timer = createServerExecutionTimer('api/primitive-fail')
+		timer.fail(404)
+
+		expect(errorSpy).toHaveBeenCalledWith('[timing] api/primitive-fail :: failed 15ms', {
+			totalMs: 15,
+			steps: [],
+			error: { value: '404' }
+		})
+	})
+})

--- a/tests/unit/server/utils/security/admin.test.ts
+++ b/tests/unit/server/utils/security/admin.test.ts
@@ -58,4 +58,16 @@ describe('security/admin', () => {
 
 		expect(isAdmin({} as never)).toBe(false)
 	})
+
+	it('returns false when admin token header is wrong and authorization header is missing', () => {
+		vi.stubGlobal(
+			'useRuntimeConfig',
+			vi.fn(() => ({ apiToken: 'master-token' }))
+		)
+		mockHeaders({
+			[SECURITY_HEADERS.adminToken]: 'wrong-token'
+		})
+
+		expect(isAdmin({} as never)).toBe(false)
+	})
 })

--- a/tests/unit/server/utils/security/request-guard.test.ts
+++ b/tests/unit/server/utils/security/request-guard.test.ts
@@ -33,6 +33,17 @@ describe('security/request-guard', () => {
 		).toEqual({ allowed: false, reason: 'invalid_fetch_site' })
 	})
 
+	it('allows protected paths when sec-fetch-site is whitespace', () => {
+		const decision = evaluateProtectedPostRequest({
+			pathname: '/api/ai/briefing',
+			requestOrigin: 'https://app.example.com',
+			fetchSiteHeader: '   ',
+			originHeader: 'https://app.example.com'
+		})
+
+		expect(decision).toEqual({ allowed: true })
+	})
+
 	it('allows protected paths for same-origin requests', () => {
 		const decision = evaluateProtectedPostRequest({
 			pathname: '/api/ai/website-analysis',
@@ -53,6 +64,29 @@ describe('security/request-guard', () => {
 		})
 
 		expect(decision).toEqual({ allowed: true })
+	})
+
+	it('blocks protected paths when request origin itself is invalid', () => {
+		const decision = evaluateProtectedPostRequest({
+			pathname: '/api/ai/briefing',
+			requestOrigin: 'not-a-url',
+			fetchSiteHeader: 'same-origin',
+			originHeader: 'https://app.example.com'
+		})
+
+		expect(decision).toEqual({ allowed: false, reason: 'invalid_origin' })
+	})
+
+	it('blocks protected paths when no valid origin metadata is available', () => {
+		const decision = evaluateProtectedPostRequest({
+			pathname: '/api/datahub/submission',
+			requestOrigin: 'https://app.example.com',
+			fetchSiteHeader: 'same-site',
+			originHeader: 'null',
+			refererHeader: 'not-a-url'
+		})
+
+		expect(decision).toEqual({ allowed: false, reason: 'invalid_origin' })
 	})
 
 	it('blocks protected paths for cross-origin origin/referer', () => {

--- a/tests/unit/server/utils/security/turnstile.test.ts
+++ b/tests/unit/server/utils/security/turnstile.test.ts
@@ -6,6 +6,8 @@ async function loadTurnstileUtil(
 		isAdmin?: boolean
 		headers?: Record<string, string | undefined>
 		verifyResult?: { success: boolean; action?: string }
+		verifyError?: unknown
+		url?: string
 		runtimeConfig?: {
 			turnstile?: { secretKey?: string }
 			public?: { mode?: { isProd?: boolean } }
@@ -37,10 +39,33 @@ async function loadTurnstileUtil(
 		'getRequestHeader',
 		vi.fn((_event: unknown, name: string) => options.headers?.[name.toLowerCase()])
 	)
+	vi.stubGlobal(
+		'getRequestURL',
+		vi.fn(() => new URL(options.url ?? 'https://app.example.com/api/ai/briefing'))
+	)
 
-	const verifyTurnstileTokenMock = vi
-		.fn()
-		.mockResolvedValue(options.verifyResult ?? { success: true })
+	const sentryScopeMock = {
+		setLevel: vi.fn(),
+		setTag: vi.fn(),
+		setContext: vi.fn()
+	}
+	const withScopeMock = vi.fn((callback: (_scope: typeof sentryScopeMock) => void) => {
+		callback(sentryScopeMock)
+	})
+	const captureExceptionMock = vi.fn()
+	const captureMessageMock = vi.fn()
+	vi.doMock('@sentry/nuxt', () => ({
+		withScope: withScopeMock,
+		captureException: captureExceptionMock,
+		captureMessage: captureMessageMock
+	}))
+
+	const verifyTurnstileTokenMock = vi.fn()
+	if (typeof options.verifyError !== 'undefined') {
+		verifyTurnstileTokenMock.mockRejectedValue(options.verifyError)
+	} else {
+		verifyTurnstileTokenMock.mockResolvedValue(options.verifyResult ?? { success: true })
+	}
 	vi.stubGlobal('verifyTurnstileToken', verifyTurnstileTokenMock)
 
 	const isAdminMock = vi.fn(() => options.isAdmin ?? false)
@@ -52,7 +77,11 @@ async function loadTurnstileUtil(
 	return {
 		assertTurnstileToken: module.assertTurnstileToken,
 		verifyTurnstileTokenMock,
-		isAdminMock
+		isAdminMock,
+		sentryScopeMock,
+		withScopeMock,
+		captureExceptionMock,
+		captureMessageMock
 	}
 }
 
@@ -75,6 +104,33 @@ describe('security/turnstile', () => {
 			statusCode: 400,
 			statusMessage: 'Turnstile token is missing'
 		})
+	})
+
+	it('throws 500 in production when turnstile secret key is missing', async () => {
+		const { assertTurnstileToken, verifyTurnstileTokenMock } = await loadTurnstileUtil({
+			runtimeConfig: {
+				turnstile: { secretKey: '   ' },
+				public: { mode: { isProd: true } }
+			}
+		})
+
+		await expect(assertTurnstileToken({} as never, 'ai_briefing')).rejects.toMatchObject({
+			statusCode: 500,
+			statusMessage: 'TURNSTILE_SECRET_KEY is missing in runtimeConfig'
+		})
+		expect(verifyTurnstileTokenMock).not.toHaveBeenCalled()
+	})
+
+	it('skips validation outside production when turnstile secret key is missing', async () => {
+		const { assertTurnstileToken, verifyTurnstileTokenMock } = await loadTurnstileUtil({
+			runtimeConfig: {
+				turnstile: { secretKey: '   ' },
+				public: { mode: { isProd: false } }
+			}
+		})
+
+		await expect(assertTurnstileToken({} as never, 'ai_briefing')).resolves.toBeUndefined()
+		expect(verifyTurnstileTokenMock).not.toHaveBeenCalled()
 	})
 
 	it('calls verifyTurnstileToken when token is present', async () => {
@@ -103,5 +159,91 @@ describe('security/turnstile', () => {
 			statusCode: 403,
 			statusMessage: 'Turnstile action does not match'
 		})
+	})
+
+	it('throws when turnstile verification reports success as false', async () => {
+		const { assertTurnstileToken } = await loadTurnstileUtil({
+			headers: {
+				[SECURITY_HEADERS.turnstileToken]: 'token-123'
+			},
+			verifyResult: {
+				success: false
+			}
+		})
+
+		await expect(assertTurnstileToken({} as never, 'ai_briefing')).rejects.toMatchObject({
+			statusCode: 403,
+			statusMessage: 'Turnstile validation failed'
+		})
+	})
+
+	it('rethrows status-code errors from token verification', async () => {
+		const verificationError = Object.assign(new Error('verification upstream error'), {
+			statusCode: 429
+		})
+		const { assertTurnstileToken, withScopeMock } = await loadTurnstileUtil({
+			headers: {
+				[SECURITY_HEADERS.turnstileToken]: 'token-123'
+			},
+			verifyError: verificationError
+		})
+
+		await expect(assertTurnstileToken({} as never, 'ai_briefing')).rejects.toBe(
+			verificationError
+		)
+		expect(withScopeMock).not.toHaveBeenCalled()
+	})
+
+	it('throws 502 and captures transport Error exceptions from token verification', async () => {
+		const transportError = new Error('network failure')
+		const {
+			assertTurnstileToken,
+			sentryScopeMock,
+			withScopeMock,
+			captureExceptionMock,
+			captureMessageMock
+		} = await loadTurnstileUtil({
+			headers: {
+				[SECURITY_HEADERS.turnstileToken]: 'token-123'
+			},
+			verifyError: transportError
+		})
+
+		await expect(assertTurnstileToken({} as never, 'ai_briefing')).rejects.toMatchObject({
+			statusCode: 502,
+			statusMessage: 'Turnstile validation could not be performed'
+		})
+		expect(withScopeMock).toHaveBeenCalledTimes(1)
+		expect(sentryScopeMock.setLevel).toHaveBeenCalledWith('error')
+		expect(sentryScopeMock.setTag).toHaveBeenCalledWith('area', 'security')
+		expect(sentryScopeMock.setTag).toHaveBeenCalledWith(
+			'kind',
+			'turnstile_verification_transport_failure'
+		)
+		expect(sentryScopeMock.setContext).toHaveBeenCalledWith('turnstile_verification', {
+			expectedAction: 'ai_briefing',
+			path: '/api/ai/briefing'
+		})
+		expect(captureExceptionMock).toHaveBeenCalledWith(transportError)
+		expect(captureMessageMock).not.toHaveBeenCalled()
+	})
+
+	it('throws 502 and captures non-Error transport failures as message', async () => {
+		const { assertTurnstileToken, captureExceptionMock, captureMessageMock } =
+			await loadTurnstileUtil({
+				headers: {
+					[SECURITY_HEADERS.turnstileToken]: 'token-123'
+				},
+				verifyError: 'socket disconnect'
+			})
+
+		await expect(assertTurnstileToken({} as never, 'ai_briefing')).rejects.toMatchObject({
+			statusCode: 502,
+			statusMessage: 'Turnstile validation could not be performed'
+		})
+		expect(captureExceptionMock).not.toHaveBeenCalled()
+		expect(captureMessageMock).toHaveBeenCalledWith(
+			'Turnstile validation transport failure with non-Error exception'
+		)
 	})
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,7 +50,13 @@ export default defineConfig({
 			reporter: ['text', 'html', 'json-summary'],
 			reportsDirectory: './coverage',
 			include: ['app/**/*.ts', 'config/**/*.ts', 'schema/**/*.ts', 'server/**/*.ts'],
-			exclude: ['**/*.d.ts', '**/*.vue', '**/README.md', 'tests/**']
+			exclude: ['**/*.d.ts', '**/*.vue', '**/README.md', 'tests/**'],
+			thresholds: {
+				lines: 85,
+				functions: 80,
+				branches: 75,
+				statements: 85
+			}
 		},
 		projects: [
 			{


### PR DESCRIPTION
- add/extend unit tests for turnstile, request-guard, admin, timing, route-guard, and datahub submission
- add coverage for content collection routes, sentry test route, assets route, and sentry cloudflare plugin
- update lint rules to ignore underscore-prefixed unused args/vars and align emit type params