### PR TITLE
feat(ai): Upgrade crawl evidence and briefing plan structure

### DIFF
--- a/config/ai.ts
+++ b/config/ai.ts
@@ -17,7 +17,9 @@ export const AI_WEBSITE_ANALYSIS_CONFIG = {
 	/** Maximum allowed page count for website analysis. */
 	maxPages: 50,
 	/** Default page count when user does not provide a value. */
-	defaultPages: 15
+	defaultPages: 15,
+	/** Max excerpt chars per page when formatting compact prompt evidence blocks. */
+	promptEvidenceExcerptMaxChars: 900
 } as const
 
 /**
@@ -124,6 +126,10 @@ export const CRAWLER_CONFIG = {
 	defaultTimeoutMs: 5_000,
 	/** Maximum excerpt length captured per crawled page. */
 	defaultMaxCharsPerPage: 2_500,
+	/** Minimum character count for using Readability extraction output. */
+	readabilityMinExcerptChars: 180,
+	/** Minimum word count for using Readability extraction output. */
+	readabilityMinExcerptWords: 28,
 	/** Upper bound for queued URLs waiting to be crawled. */
 	defaultMaxQueuedUrls: 500,
 	/** Default worker fetch concurrency for crawl/page requests. */
@@ -143,7 +149,7 @@ export const CRAWLER_CONFIG = {
 	/** Unstorage namespace used for crawl result caching. */
 	cacheNamespace: 'cache',
 	/** Prefix used when building deterministic crawl cache keys. */
-	cacheKeyPrefix: 'ai:crawl:v3',
+	cacheKeyPrefix: 'ai:crawl:v5',
 	/** Cache retention time for crawl results (2 days). */
 	cacheTtlMs: 2 * 24 * 60 * 60 * 1000,
 	/** Candidate sitemap locations to probe on each domain. */

--- a/content/_prompts/01.ai-briefing-system.md
+++ b/content/_prompts/01.ai-briefing-system.md
@@ -25,7 +25,7 @@ Gebruik exact deze opbouw:
 4. Aanbevolen onderdelen en inhoud
 5. Structuur en navigatiekeuzes
 6. Prioriteitenmatrix (impact x inspanning)
-7. Uitvoeringsplan eerste 90 dagen
+7. Voorgesteld stappenplan
 
 Outputregels:
 
@@ -35,5 +35,9 @@ Outputregels:
   - koppen met ##
   - korte alinea's
   - bullet points
+- De sectie `Voorgesteld stappenplan` moet een volgordelijke actielijst zijn die de
+  prioriteitenmatrix vertaalt naar implementatievolgorde (stap 1, stap 2, stap 3, ...).
+- Geen tijdsindeling per dagen/weken.
+- Geen bureau-terugkoppelingstaal zoals `deliverables`, `kickoff`, `livegang` als planningslabels.
 - Geen code blocks.
 - Geen uitleg over je werkwijze.

--- a/docs/ai-integration/README.md
+++ b/docs/ai-integration/README.md
@@ -63,9 +63,10 @@ What the route does:
 2. Crawls the requested domain server-side (capped, same-domain).
 3. Loads system prompt from content collection (`content/_prompts`).
 4. Fetches reference criteria from `/llms-full.txt` (fallback `/llms.txt`).
-5. Requires at least one crawled page with non-empty text excerpt.
-6. Sends validated crawl context + reference to OpenAI.
-7. Returns typed response payload with `analysis`, `analysedPages`, and `usedSources`.
+5. Requires at least one crawled page with meaningful textual evidence.
+6. Formats per-page evidence blocks with compact excerpt + full cleaned semantic content.
+7. Sends validated crawl context + reference to OpenAI.
+8. Returns typed response payload with `analysis`, `analysedPages`, and `usedSources`.
 
 Controller + helpers:
 
@@ -167,7 +168,7 @@ Key response fields:
 
 - `analysis`, `briefing`
 - `analysedPages` and `usedSources` for analysis traceability
-- `usedSources` includes the requested URL plus evidence-page URLs with non-empty crawl excerpts
+- `usedSources` includes the requested URL plus evidence-page URLs with meaningful crawl evidence
 - `crawledPages` kept for backward compatibility
 
 ## PDF Integration
@@ -191,6 +192,8 @@ Implemented safeguards:
 - Sentry Zod integration enriches captured `ZodError` events with issue details
 - server-side same-domain crawl with page caps
 - llms-full reference criteria included in analysis prompt
+- crawler extraction uses Readability-first with fallback to the existing simple extraction path
+- per-page evidence blocks include compact excerpt plus full cleaned semantic HTML
 - structured model output parsing before analysis markdown assembly
 - OpenAI SDK calls are instrumented through the shared client factory (`server/utils/ai/openai.ts`)
 - compatibility fallback for model-specific unsupported reasoning/verbosity params
@@ -204,10 +207,19 @@ Implemented safeguards:
 Remaining risk:
 
 - model output may still over-generalize relative to crawled excerpts
-- larger crawls increase token pressure and can still require tuning of `max_output_tokens`
+- larger crawls (especially with full semantic page evidence) increase token pressure and may
+  require tuning of `max_output_tokens`
 - users should review AI output before finalizing PDF
 
 ## Runtime and Config
+
+Current provider implementation:
+
+- OpenAI (`server/utils/ai/openai.ts`)
+- provider-compatibility fallback handling in `server/utils/ai/response.ts` and
+  `server/utils/ai/route-request.ts`
+- prompt/crawl shaping (`analysis.ts`, `briefing.ts`, `crawler/*`) remains provider-agnostic and
+  reusable
 
 Runtime config:
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"@iconify-json/hugeicons": "catalog:",
 		"@iconify-json/lucide": "catalog:",
 		"@iconify-json/simple-icons": "catalog:",
+		"@mozilla/readability": "catalog:",
 		"@nuxt/content": "catalog:",
 		"@nuxt/eslint": "catalog:",
 		"@nuxt/image": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ catalogs:
     '@iconify-json/simple-icons':
       specifier: 1.2.75
       version: 1.2.75
+    '@mozilla/readability':
+      specifier: 0.6.0
+      version: 0.6.0
     '@nuxt/content':
       specifier: 3.12.0
       version: 3.12.0
@@ -263,6 +266,9 @@ importers:
       '@iconify-json/simple-icons':
         specifier: 'catalog:'
         version: 1.2.75
+      '@mozilla/readability':
+        specifier: 'catalog:'
+        version: 0.6.0
       '@nuxt/content':
         specifier: 'catalog:'
         version: 3.12.0(better-sqlite3@12.8.0)(magicast@0.5.2)(valibot@1.3.1(typescript@5.9.3))
@@ -1514,6 +1520,10 @@ packages:
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@mozilla/readability@0.6.0':
+    resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
+    engines: {node: '>=14.0.0'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -10474,6 +10484,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@mozilla/readability@0.6.0': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ catalog:
   '@iconify-json/hugeicons': 1.2.24
   '@iconify-json/lucide': 1.2.99
   '@iconify-json/simple-icons': 1.2.75
+  '@mozilla/readability': 0.6.0
   '@nuxt/content': 3.12.0
   '@nuxt/eslint': 1.15.2
   '@nuxt/image': 2.0.0

--- a/server/api/ai/README.md
+++ b/server/api/ai/README.md
@@ -82,6 +82,7 @@ Timing logs now include resolved model metadata on:
 
 - `website-analysis.post.ts`
   - crawl evidence validation
+  - includes compact excerpt + full cleaned semantic page content in prompt evidence
   - criteria-based analysis generation
   - source traceability fields
 - `briefing.post.ts`

--- a/server/api/ai/website-analysis.post.ts
+++ b/server/api/ai/website-analysis.post.ts
@@ -63,7 +63,7 @@ export default defineEventHandler(async (event) => {
 			crawledPages: crawledPages.length
 		})
 
-		const evidencePages = crawledPages.filter((page) => page.excerpt.trim().length > 0)
+		const evidencePages = crawledPages.filter(hasPageEvidence)
 		timer.mark('evidence_filtered', {
 			evidencePages: evidencePages.length
 		})
@@ -294,6 +294,24 @@ export default defineEventHandler(async (event) => {
 		throw error
 	}
 })
+
+/**
+ * Returns true when a crawled page has meaningful textual evidence.
+ *
+ * @param page - Crawled page snapshot.
+ * @returns Whether the page can be used as analysis evidence.
+ */
+function hasPageEvidence(page: { excerpt: string; fullContent: string }): boolean {
+	if (page.excerpt.trim().length > 0) {
+		return true
+	}
+
+	const textFromSemanticHtml = page.fullContent
+		.replace(/<[^>]+>/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim()
+	return textFromSemanticHtml.length > 0
+}
 
 /**
  * Tries to parse structured analysis payload from a text response.

--- a/server/utils/ai/README.md
+++ b/server/utils/ai/README.md
@@ -13,6 +13,7 @@ files remain focused on boundary handling and orchestration.
   - fetches llms criteria documents (`/llms-full.txt`, fallback `/llms.txt`)
 - `analysis.ts`
   - builds website-analysis prompt input blocks from crawl evidence and metadata
+  - formats per-page evidence as compact excerpt + full cleaned semantic content
 - `analysis-output.ts`
   - structured schema for website-analysis model output + markdown assembly
 - `briefing.ts`
@@ -38,6 +39,8 @@ files remain focused on boundary handling and orchestration.
 - Avoid embedding runtime secrets here; use `useRuntimeConfig` only in dedicated client/bootstrap
   utility (`openai.ts`).
 - Keep AI behavior tuning centralized in [`config/ai.ts`](../../../config/ai.ts).
+- Keep provider-specific logic isolated in dedicated utilities (`openai.ts`, compatibility helpers)
+  so prompt/crawl orchestration can be reused for future providers.
 
 ## Related Docs
 

--- a/server/utils/ai/analysis.ts
+++ b/server/utils/ai/analysis.ts
@@ -1,5 +1,7 @@
 import type { CrawledWebsitePage } from '../crawler/types'
 
+import { AI_WEBSITE_ANALYSIS_CONFIG } from '@ai'
+
 /**
  * Builds an allowlist for domain-constrained web search.
  *
@@ -68,7 +70,12 @@ export function formatCrawledPagesForPrompt(pages: CrawledWebsitePage[]): string
 		lines.push(`## Pagina ${index + 1}`)
 		lines.push(`URL: ${page.url}`)
 		lines.push(`Titel: ${page.title || 'Onbekend'}`)
-		lines.push(`Inhoud (uittreksel): ${page.excerpt || 'Geen tekst gevonden.'}`)
+		lines.push(`Hoofdkop (H1): ${page.mainHeading || 'Onbekend'}`)
+		lines.push(`Inhoud (compact bewijs): ${toCompactPromptExcerpt(page.excerpt)}`)
+		lines.push('Kerninhoud (volledig opgeschoond, semantische HTML):')
+		lines.push('```html')
+		lines.push(toCodeFenceSafeHtml(page.fullContent || '<p>Geen inhoud gevonden.</p>'))
+		lines.push('```')
 		lines.push('')
 	}
 
@@ -87,19 +94,19 @@ function formatCrawlCoverageSummary(pages: CrawledWebsitePage[], maxPages: numbe
 		return "- Geen pagina's gecrawld."
 	}
 
-	const withExcerpt = pages.filter((page) => page.excerpt.trim().length > 0)
+	const pagesWithEvidence = pages.filter(hasPageEvidence)
 	const withTitle = pages.filter((page) => Boolean(page.title?.trim())).length
 	const averageExcerptLength = Math.round(
-		withExcerpt.reduce((sum, page) => sum + page.excerpt.length, 0) /
-			Math.max(withExcerpt.length, 1)
+		pagesWithEvidence.reduce((sum, page) => sum + resolvePageEvidenceTextLength(page), 0) /
+			Math.max(pagesWithEvidence.length, 1)
 	)
 	const pathSegments = countTopPathSegments(pages)
 
 	return [
 		`- Geanalyseerde pagina's: ${pages.length} van max ${maxPages}`,
-		`- Pagina's met bruikbare tekst: ${withExcerpt.length}`,
+		`- Pagina's met bruikbare tekst: ${pagesWithEvidence.length}`,
 		`- Pagina's met titel: ${withTitle}`,
-		`- Gemiddelde excerpt-lengte: ${averageExcerptLength} tekens`,
+		`- Gemiddelde evidencetekst-lengte: ${averageExcerptLength} tekens`,
 		`- Meest voorkomende pad-segmenten: ${pathSegments}`
 	].join('\n')
 }
@@ -128,4 +135,87 @@ function countTopPathSegments(pages: CrawledWebsitePage[]): string {
 		.map(([segment, count]) => `${segment} (${count})`)
 
 	return top.length > 0 ? top.join(', ') : 'Geen'
+}
+
+/**
+ * Compacts crawl excerpts for prompt evidence blocks.
+ *
+ * @param excerpt - Raw excerpt.
+ * @returns Prompt-safe compact excerpt.
+ */
+function toCompactPromptExcerpt(excerpt: string): string {
+	const normalized = excerpt.replace(/\s+/g, ' ').trim()
+	if (!normalized) {
+		return 'Geen tekst gevonden.'
+	}
+
+	const maxChars = AI_WEBSITE_ANALYSIS_CONFIG.promptEvidenceExcerptMaxChars
+	if (normalized.length <= maxChars) {
+		return normalized
+	}
+
+	const truncated = normalized.slice(0, maxChars)
+	const sentenceBreak = Math.max(
+		truncated.lastIndexOf('. '),
+		truncated.lastIndexOf('! '),
+		truncated.lastIndexOf('? ')
+	)
+	if (sentenceBreak >= Math.floor(maxChars * 0.6)) {
+		return `${truncated.slice(0, sentenceBreak + 1).trim()} …`
+	}
+
+	const lastSpace = truncated.lastIndexOf(' ')
+	if (lastSpace > 0) {
+		return `${truncated.slice(0, lastSpace).trim()} …`
+	}
+
+	return `${truncated.trim()} …`
+}
+
+/**
+ * Makes semantic HTML safe for fenced markdown embedding.
+ *
+ * @param html - Semantic HTML evidence.
+ * @returns Markdown fence-safe HTML.
+ */
+function toCodeFenceSafeHtml(html: string): string {
+	return html.replaceAll('```', '&#96;&#96;&#96;')
+}
+
+/**
+ * Returns whether a crawled page has meaningful evidence text.
+ *
+ * @param page - Crawled page.
+ * @returns Whether page evidence is non-empty.
+ */
+function hasPageEvidence(page: CrawledWebsitePage): boolean {
+	return resolvePageEvidenceText(page).length > 0
+}
+
+/**
+ * Returns evidence text length for one crawled page.
+ *
+ * @param page - Crawled page.
+ * @returns Evidence text length.
+ */
+function resolvePageEvidenceTextLength(page: CrawledWebsitePage): number {
+	return resolvePageEvidenceText(page).length
+}
+
+/**
+ * Resolves best-effort plain evidence text from page snapshot.
+ *
+ * @param page - Crawled page.
+ * @returns Plain evidence text.
+ */
+function resolvePageEvidenceText(page: CrawledWebsitePage): string {
+	const excerpt = page.excerpt.trim()
+	if (excerpt) {
+		return excerpt
+	}
+
+	return page.fullContent
+		.replace(/<[^>]+>/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim()
 }

--- a/server/utils/crawler/README.md
+++ b/server/utils/crawler/README.md
@@ -12,7 +12,7 @@ Primary entrypoint:
 - Deterministic traversal behavior
 - Strict bounds on memory/time/queue growth
 - Better coverage via sitemap and robots discovery
-- Output shaped for AI prompt safety (short excerpts, bounded pages)
+- Output shaped for AI prompt quality (bounded pages + cleaned semantic content)
 
 ## Module Responsibilities
 
@@ -22,10 +22,12 @@ Primary entrypoint:
   - bounded fetch/read helpers with timeout + byte limits
 - `html.ts`
   - HTML parsing and link/content extraction (`linkedom`)
+  - optional Readability-first content extraction (`@mozilla/readability`) with fallback to
+    `main/article/body`
 - `sitemap.ts`
   - sitemap + robots discovery and recursive sitemap index handling (`fast-xml-parser`)
 - `cache.ts`
-  - 31-day crawl cache read/write via `useStorage`
+  - configured-TTL crawl cache read/write via `useStorage` (currently 2 days)
 - `url.ts`
   - normalization, allowlist checks, concurrency clamp
 - `types.ts`
@@ -41,6 +43,8 @@ Primary entrypoint:
 - Timeout per request enforced
 - Byte limits enforced for HTML/text resources
 - Excerpts are truncated to configured max chars
+- Readability extraction is used only when output is sufficiently strong; fallback remains available
+- Full page evidence keeps cleaned semantic content (attributes/junk stripped) for AI context
 - Cached results are only stored when at least one page has meaningful text
 
 ## Configuration

--- a/server/utils/crawler/cache.ts
+++ b/server/utils/crawler/cache.ts
@@ -62,7 +62,7 @@ export async function getCachedCrawlPages(cacheKey: string): Promise<CrawledWebs
 }
 
 /**
- * Stores crawl results for 31 days.
+ * Stores crawl results for configured cache TTL (currently 2 days).
  *
  * @param cacheKey - Crawl cache key.
  * @param pages - Crawl result pages.
@@ -72,8 +72,20 @@ export async function setCachedCrawlPages(
 	cacheKey: string,
 	pages: CrawledWebsitePage[]
 ): Promise<void> {
-	// Only cache results that contain at least one meaningful excerpt.
-	if (!pages.some((page) => page.excerpt.trim().length > 0)) {
+	// Only cache results that contain at least one meaningful evidence payload.
+	if (
+		!pages.some((page) => {
+			if (page.excerpt.trim().length > 0) {
+				return true
+			}
+
+			const textFromSemanticHtml = page.fullContent
+				.replace(/<[^>]+>/g, ' ')
+				.replace(/\s+/g, ' ')
+				.trim()
+			return textFromSemanticHtml.length > 0
+		})
+	) {
 		return
 	}
 
@@ -98,6 +110,8 @@ function isCrawledWebsitePage(value: unknown): value is CrawledWebsitePage {
 		page &&
 		typeof page.url === 'string' &&
 		typeof page.excerpt === 'string' &&
-		(page.title === undefined || typeof page.title === 'string')
+		typeof page.fullContent === 'string' &&
+		(page.title === undefined || typeof page.title === 'string') &&
+		(page.mainHeading === undefined || typeof page.mainHeading === 'string')
 	)
 }

--- a/server/utils/crawler/html.ts
+++ b/server/utils/crawler/html.ts
@@ -1,5 +1,7 @@
 import type { ParsedHtmlCrawlData, UnknownRecord } from './types'
 
+import { CRAWLER_CONFIG } from '@ai'
+import { Readability } from '@mozilla/readability'
 import { parseHTML } from 'linkedom/worker'
 
 import { asRecord, callRecordMethod, toIterableArray } from './records'
@@ -28,33 +30,48 @@ export function parseHtmlForCrawl(
 		if (!documentRecord) {
 			return {
 				excerpt: '',
+				fullContent: '',
 				links: []
 			}
 		}
 
 		for (const node of querySelectorAllRecords(
 			documentRecord,
-			'script,style,noscript,template'
+			'script,style,noscript,template,header,footer,nav,aside'
 		)) {
 			callRecordMethod(node, 'remove')
 		}
 
 		const title = normalizeText(getNodeText(querySelectorOneRecord(documentRecord, 'title')))
-		const contentRoot =
-			querySelectorOneRecord(documentRecord, 'main') ??
-			querySelectorOneRecord(documentRecord, 'article') ??
-			asRecord(documentRecord.body)
-		const excerpt = normalizeText(getNodeText(contentRoot)).slice(0, maxCharsPerPage).trim()
+		const mainHeading = normalizeText(getNodeText(querySelectorOneRecord(documentRecord, 'h1')))
+		const fallbackContent = extractFallbackContent(documentRecord, maxCharsPerPage)
+		const readabilityCandidate = extractReadabilityCandidate(documentRecord)
+		const readabilityText = normalizeText(readabilityCandidate?.text)
+		const usesReadability = isReadabilityExcerptViable(readabilityText)
+		const excerpt = usesReadability
+			? readabilityText.slice(0, maxCharsPerPage).trim()
+			: fallbackContent.excerpt
+		const fullContent = usesReadability
+			? toSemanticContent(readabilityCandidate?.contentHtml, readabilityText)
+			: fallbackContent.fullContent
 		const links = extractLinksFromDocument(documentRecord, baseUrl, allowedDomains)
+		const resolvedTitle = usesReadability
+			? normalizeText(readabilityCandidate?.title) || title
+			: title
 
-		return {
-			title: title || undefined,
-			excerpt,
-			links
+		const result: ParsedHtmlCrawlData = { excerpt, fullContent, links }
+		if (resolvedTitle) {
+			result.title = resolvedTitle
 		}
+		if (mainHeading) {
+			result.mainHeading = mainHeading
+		}
+
+		return result
 	} catch {
 		return {
 			excerpt: '',
+			fullContent: '',
 			links: []
 		}
 	}
@@ -98,6 +115,252 @@ function extractLinksFromDocument(
 	}
 
 	return [...urls]
+}
+
+/**
+ * Extracts fallback excerpt and cleaned semantic content from `main`, `article`, or `body`.
+ *
+ * @param documentRecord - Parsed HTML document as generic object.
+ * @param maxCharsPerPage - Max excerpt length.
+ * @returns Fallback excerpt plus cleaned semantic content.
+ */
+function extractFallbackContent(
+	documentRecord: UnknownRecord,
+	maxCharsPerPage: number
+): { excerpt: string; fullContent: string } {
+	const contentRoot =
+		querySelectorOneRecord(documentRecord, 'main') ??
+		querySelectorOneRecord(documentRecord, 'article') ??
+		asRecord(documentRecord.body)
+
+	const excerpt = normalizeText(getNodeText(contentRoot)).slice(0, maxCharsPerPage).trim()
+	const fullContent = toSemanticContent(readNodeOuterHtml(contentRoot), excerpt)
+	return {
+		excerpt,
+		fullContent
+	}
+}
+
+/**
+ * Attempts to parse raw Readability output.
+ *
+ * @param documentRecord - Parsed document object.
+ * @returns Readability title + text payload when available.
+ */
+function extractReadabilityCandidate(
+	documentRecord: UnknownRecord
+): { title?: string; text: string; contentHtml?: string } | null {
+	try {
+		const cloneNode = documentRecord.cloneNode
+		if (typeof cloneNode !== 'function') {
+			return null
+		}
+
+		const readabilityDocument = cloneNode.call(documentRecord, true)
+		const article = new Readability(readabilityDocument as never).parse()
+		const fullText = normalizeText(article?.textContent)
+		if (!fullText) {
+			return null
+		}
+
+		const title = normalizeText(article?.title)
+		return {
+			title: title || undefined,
+			text: fullText,
+			contentHtml: typeof article?.content === 'string' ? article.content : undefined
+		}
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Checks whether a Readability excerpt is strong enough to trust as primary evidence.
+ *
+ * @param excerpt - Extracted readability text.
+ * @returns Whether readability output is viable.
+ */
+function isReadabilityExcerptViable(excerpt: string): boolean {
+	if (!excerpt) {
+		return false
+	}
+
+	const wordCount = excerpt.split(/\s+/).filter(Boolean).length
+	return (
+		excerpt.length >= CRAWLER_CONFIG.readabilityMinExcerptChars ||
+		wordCount >= CRAWLER_CONFIG.readabilityMinExcerptWords
+	)
+}
+
+/**
+ * Builds semantic cleaned content from extracted HTML/text.
+ *
+ * @param rawHtml - Raw extracted HTML content.
+ * @param fallbackText - Text fallback when semantic HTML is unavailable.
+ * @returns Semantic cleaned page content.
+ */
+function toSemanticContent(rawHtml: string | null | undefined, fallbackText: string): string {
+	const sanitizedHtml = sanitizeSemanticHtml(rawHtml)
+	if (sanitizedHtml && /<[^>]+>/.test(sanitizedHtml)) {
+		return sanitizedHtml
+	}
+
+	const normalizedText = normalizeText(sanitizedHtml || fallbackText)
+	if (!normalizedText) {
+		return ''
+	}
+
+	return `<p>${escapeHtml(normalizedText)}</p>`
+}
+
+/**
+ * Sanitizes content HTML and keeps semantic structure with stripped attributes.
+ *
+ * @param rawHtml - Raw HTML.
+ * @returns Semantic sanitized HTML.
+ */
+function sanitizeSemanticHtml(rawHtml: string | null | undefined): string {
+	if (!rawHtml) {
+		return ''
+	}
+
+	const allowedTags = new Set([
+		'main',
+		'article',
+		'section',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+		'p',
+		'ul',
+		'ol',
+		'li',
+		'blockquote',
+		'pre',
+		'code',
+		'table',
+		'thead',
+		'tbody',
+		'tr',
+		'th',
+		'td',
+		'strong',
+		'em',
+		'a',
+		'hr',
+		'br'
+	])
+	let sanitized = rawHtml
+		.replace(/<!--[\s\S]*?-->/g, '')
+		.replace(
+			/<(script|style|noscript|template|svg|canvas|iframe|form|nav|header|footer|aside)\b[^>]*>[\s\S]*?<\/\1>/gi,
+			''
+		)
+		.replace(/<\s*(html|head|body)\b[^>]*>/gi, '')
+		.replace(/<\s*\/\s*(html|head|body)\s*>/gi, '')
+		.replace(/<\s*([a-z0-9:-]+)(\s[^>]*)?>/gi, (match, rawTag, attrs) => {
+			const tag = String(rawTag).toLowerCase()
+			if (!allowedTags.has(tag)) {
+				return ''
+			}
+
+			// Keep anchor target text only; drop all attributes except href.
+			if (tag === 'a') {
+				const hrefMatch = String(attrs ?? '').match(/\bhref\s*=\s*(['"])(.*?)\1/i)
+				const href = hrefMatch?.[2]?.trim()
+				const safeHref = normalizeSemanticHref(href)
+				return safeHref ? `<a href="${escapeHtmlAttribute(safeHref)}">` : '<a>'
+			}
+
+			return `<${tag}>`
+		})
+		.replace(/<\s*\/\s*([a-z0-9:-]+)\s*>/gi, (match, rawTag) => {
+			const tag = String(rawTag).toLowerCase()
+			return allowedTags.has(tag) ? `</${tag}>` : ''
+		})
+		.replace(/\n{3,}/g, '\n\n')
+		.trim()
+
+	// Remove empty semantic wrappers that add no information.
+	sanitized = sanitized.replace(/<(article|section|p|li|blockquote|pre|code)\s*>\s*<\/\1>/gi, '')
+
+	return sanitized.trim()
+}
+
+/**
+ * Reads `outerHTML` from a node-like record.
+ *
+ * @param nodeRecord - Node-like object.
+ * @returns Outer HTML or empty string.
+ */
+function readNodeOuterHtml(nodeRecord: UnknownRecord | null): string {
+	if (!nodeRecord) {
+		return ''
+	}
+
+	const outerHtml = nodeRecord.outerHTML
+	return typeof outerHtml === 'string' ? outerHtml : ''
+}
+
+/**
+ * Escapes text for HTML context.
+ *
+ * @param value - Raw value.
+ * @returns Escaped HTML text.
+ */
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#39;')
+}
+
+/**
+ * Escapes attribute values for HTML context.
+ *
+ * @param value - Raw attribute value.
+ * @returns Escaped attribute text.
+ */
+function escapeHtmlAttribute(value: string): string {
+	return escapeHtml(value)
+}
+
+/**
+ * Normalizes href values retained in semantic evidence HTML.
+ *
+ * @param href - Raw href value.
+ * @returns Safe normalized href, or null when unsupported.
+ */
+function normalizeSemanticHref(href: string | undefined): string | null {
+	if (!href) {
+		return null
+	}
+
+	const normalized = href.trim()
+	if (!normalized) {
+		return null
+	}
+
+	if (
+		normalized.startsWith('/') ||
+		normalized.startsWith('./') ||
+		normalized.startsWith('../') ||
+		normalized.startsWith('#')
+	) {
+		return normalized
+	}
+
+	const lowercase = normalized.toLowerCase()
+	if (lowercase.startsWith('http://') || lowercase.startsWith('https://')) {
+		return normalized
+	}
+
+	return null
 }
 
 /**

--- a/server/utils/crawler/types.ts
+++ b/server/utils/crawler/types.ts
@@ -12,7 +12,9 @@ export type CrawlWebsiteArgs = {
 
 export type ParsedHtmlCrawlData = {
 	title?: string
+	mainHeading?: string
 	excerpt: string
+	fullContent: string
 	links: string[]
 }
 
@@ -24,7 +26,9 @@ export type SitemapDocumentEntries = {
 export type CrawledWebsitePage = {
 	url: string
 	title?: string
+	mainHeading?: string
 	excerpt: string
+	fullContent: string
 }
 
 export type CrawlCacheEntry = {

--- a/server/utils/crawler/website.ts
+++ b/server/utils/crawler/website.ts
@@ -18,7 +18,7 @@ import { clampConcurrency, isAllowedUrl, normalizeUrl } from './url'
  * - short per-request timeout
  * - short text excerpts for prompt safety
  * - bounded concurrency
- * - cached crawl results (31 days)
+ * - cached crawl results (configured TTL, currently 2 days)
  *
  * @param args - Crawl configuration.
  * @returns Deterministic list of crawled pages and excerpts.
@@ -158,7 +158,8 @@ export async function crawlWebsiteForAnalysis(
 	if (pages.length > 0 && !pages.some((page) => page.url === entryUrl)) {
 		pages.unshift({
 			url: entryUrl,
-			excerpt: ''
+			excerpt: '',
+			fullContent: ''
 		})
 	}
 
@@ -196,13 +197,18 @@ async function crawlSinglePage(
 	}
 
 	const parsed = parseHtmlForCrawl(fetched.html, resolvedUrl, allowedDomains, maxCharsPerPage)
+	const page: CrawledWebsitePage = {
+		url: resolvedUrl,
+		title: parsed.title,
+		excerpt: parsed.excerpt,
+		fullContent: parsed.fullContent
+	}
+	if (parsed.mainHeading) {
+		page.mainHeading = parsed.mainHeading
+	}
 
 	return {
-		page: {
-			url: resolvedUrl,
-			title: parsed.title,
-			excerpt: parsed.excerpt
-		},
+		page,
 		links: parsed.links
 	}
 }

--- a/tests/unit/server/api/ai-website-analysis.post.test.ts
+++ b/tests/unit/server/api/ai-website-analysis.post.test.ts
@@ -16,7 +16,7 @@ async function loadHandler(
 	options: {
 		parseImpl?: ReturnType<typeof vi.fn>
 		createImpl?: ReturnType<typeof vi.fn>
-		crawlPages?: Array<{ url: string; title?: string; excerpt: string }>
+		crawlPages?: Array<{ url: string; title?: string; excerpt: string; fullContent: string }>
 		body?: unknown
 	} = {}
 ) {
@@ -31,8 +31,18 @@ async function loadHandler(
 	const createImpl = options.createImpl ?? vi.fn()
 	const assertTurnstileTokenMock = vi.fn().mockResolvedValue(undefined)
 	const crawlPages = options.crawlPages ?? [
-		{ url: 'https://example.com', title: 'Home', excerpt: 'Welkom op de site' },
-		{ url: 'https://example.com/contact', title: 'Contact', excerpt: '' }
+		{
+			url: 'https://example.com',
+			title: 'Home',
+			excerpt: 'Welkom op de site',
+			fullContent: '<main><p>Welkom op de site</p></main>'
+		},
+		{
+			url: 'https://example.com/contact',
+			title: 'Contact',
+			excerpt: '',
+			fullContent: ''
+		}
 	]
 
 	vi.stubGlobal('defineEventHandler', (handler: unknown) => handler)
@@ -109,7 +119,9 @@ describe('POST /api/ai/website-analysis', () => {
 
 	it('throws when crawl returns no pages with evidence text', async () => {
 		const { handler, parseImpl } = await loadHandler({
-			crawlPages: [{ url: 'https://example.com', title: 'Home', excerpt: '   ' }]
+			crawlPages: [
+				{ url: 'https://example.com', title: 'Home', excerpt: '   ', fullContent: '' }
+			]
 		})
 
 		await expect(handler({} as never)).rejects.toMatchObject({
@@ -118,6 +130,25 @@ describe('POST /api/ai/website-analysis', () => {
 				'AI website analysis could not retrieve usable page content from the provided website'
 		})
 		expect(parseImpl).not.toHaveBeenCalled()
+	})
+
+	it('accepts a page as evidence when excerpt is empty but semantic content has text', async () => {
+		const { handler, parseImpl } = await loadHandler({
+			crawlPages: [
+				{
+					url: 'https://example.com/home',
+					title: 'Home',
+					excerpt: '   ',
+					fullContent: '<main><h1>Home</h1><p>Betrouwbare tekst</p></main>'
+				}
+			]
+		})
+
+		const result = await handler({} as never)
+
+		expect(result.analysis).toContain('## Korte samenvatting')
+		expect(result.crawledPages).toEqual([{ url: 'https://example.com/home', title: 'Home' }])
+		expect(parseImpl).toHaveBeenCalledTimes(1)
 	})
 
 	it('falls back to plain response mode when structured parse fails', async () => {

--- a/tests/unit/server/utils/ai/analysis.test.ts
+++ b/tests/unit/server/utils/ai/analysis.test.ts
@@ -24,18 +24,55 @@ describe('server/utils/ai/analysis', () => {
 			{
 				url: 'https://example.com/over',
 				title: 'Over ons',
-				excerpt: 'Informatie over de regio'
+				mainHeading: 'Samen bouwen aan de regio',
+				excerpt: 'Informatie over de regio',
+				fullContent: '<article><h2>Over ons</h2><p>Informatie over de regio</p></article>'
 			},
 			{
 				url: 'https://example.com/contact',
-				excerpt: ''
+				excerpt: '',
+				fullContent: ''
 			}
 		])
 
 		expect(output).toContain('## Pagina 1')
 		expect(output).toContain('Titel: Over ons')
+		expect(output).toContain('Hoofdkop (H1): Samen bouwen aan de regio')
 		expect(output).toContain('Titel: Onbekend')
-		expect(output).toContain('Inhoud (uittreksel): Geen tekst gevonden.')
+		expect(output).toContain('Hoofdkop (H1): Onbekend')
+		expect(output).toContain('Inhoud (compact bewijs): Geen tekst gevonden.')
+		expect(output).toContain('Kerninhoud (volledig opgeschoond, semantische HTML):')
+		expect(output).toContain('<p>Geen inhoud gevonden.</p>')
+	})
+
+	it('keeps code-fence safety for full semantic content blocks', () => {
+		const output = formatCrawledPagesForPrompt([
+			{
+				url: 'https://example.com/handleidingen',
+				excerpt: 'Gebruik handleiding',
+				fullContent: '<article><pre>```voorbeeld```</pre></article>'
+			}
+		])
+
+		expect(output).toContain('&#96;&#96;&#96;voorbeeld&#96;&#96;&#96;')
+		expect(output).not.toContain('```voorbeeld```')
+	})
+
+	it('compacts long evidence excerpts per page', () => {
+		const output = formatCrawledPagesForPrompt([
+			{
+				url: 'https://example.com/lang',
+				excerpt: 'Lang bewijs '.repeat(220),
+				fullContent: '<article><p>Lang bewijs</p></article>'
+			}
+		])
+
+		const evidenceLine = output
+			.split('\n')
+			.find((line) => line.startsWith('Inhoud (compact bewijs): '))
+		expect(evidenceLine).toBeTruthy()
+		expect(evidenceLine).toContain(' …')
+		expect(evidenceLine!.length).toBeLessThan(1_050)
 	})
 
 	it('includes crawl coverage + constraints in website-analysis prompt', () => {
@@ -48,17 +85,20 @@ describe('server/utils/ai/analysis', () => {
 				{
 					url: 'https://example.com/nieuws',
 					title: 'Nieuws',
-					excerpt: 'A'.repeat(40)
+					excerpt: 'A'.repeat(40),
+					fullContent: '<article><h2>Nieuws</h2><p>AAA</p></article>'
 				},
 				{
 					url: 'https://example.com/nieuws/2',
 					title: '',
-					excerpt: 'B'.repeat(20)
+					excerpt: 'B'.repeat(20),
+					fullContent: '<article><h2>Nieuws 2</h2><p>BBB</p></article>'
 				},
 				{
 					url: 'https://example.com/contact',
 					title: 'Contact',
-					excerpt: ''
+					excerpt: '',
+					fullContent: '<article><h2>Contact</h2></article>'
 				}
 			]
 		})
@@ -66,8 +106,9 @@ describe('server/utils/ai/analysis', () => {
 		expect(output).toContain('Te analyseren URL: https://example.com')
 		expect(output).toContain('Regio: Utrecht')
 		expect(output).toContain("- Geanalyseerde pagina's: 3 van max 3")
-		expect(output).toContain("- Pagina's met bruikbare tekst: 2")
+		expect(output).toContain("- Pagina's met bruikbare tekst: 3")
 		expect(output).toContain('- Meest voorkomende pad-segmenten: nieuws (2), contact (1)')
+		expect(output).toContain('- Gemiddelde evidencetekst-lengte: 22 tekens')
 		expect(output).toContain('Gebruik uitsluitend de hierboven aangeleverde crawl-context')
 	})
 })

--- a/tests/unit/server/utils/crawler/cache.test.ts
+++ b/tests/unit/server/utils/crawler/cache.test.ts
@@ -41,7 +41,9 @@ describe('crawler/cache', () => {
 		const expiredStorage = createStorageMock({
 			getItemValue: {
 				expiresAt: Date.now() - 1000,
-				pages: [{ url: 'https://example.com', excerpt: 'tekst' }]
+				pages: [
+					{ url: 'https://example.com', excerpt: 'tekst', fullContent: '<p>tekst</p>' }
+				]
 			}
 		})
 		vi.stubGlobal(
@@ -86,8 +88,13 @@ describe('crawler/cache', () => {
 			getItemValue: {
 				expiresAt: Date.now() + 60_000,
 				pages: [
-					{ url: 'https://example.com/a', excerpt: 'A', title: 'A' },
-					{ url: 'https://example.com/b', excerpt: 'B' },
+					{
+						url: 'https://example.com/a',
+						excerpt: 'A',
+						fullContent: '<p>A</p>',
+						title: 'A'
+					},
+					{ url: 'https://example.com/b', excerpt: 'B', fullContent: '<p>B</p>' },
 					{ excerpt: 'missing url' }
 				]
 			}
@@ -98,13 +105,13 @@ describe('crawler/cache', () => {
 		)
 
 		await expect(getCachedCrawlPages('cache:valid')).resolves.toEqual([
-			{ url: 'https://example.com/a', excerpt: 'A', title: 'A' },
-			{ url: 'https://example.com/b', excerpt: 'B' }
+			{ url: 'https://example.com/a', excerpt: 'A', fullContent: '<p>A</p>', title: 'A' },
+			{ url: 'https://example.com/b', excerpt: 'B', fullContent: '<p>B</p>' }
 		])
 		expect(storage.removeItem).not.toHaveBeenCalled()
 	})
 
-	it('stores only crawl results with meaningful excerpts', async () => {
+	it('stores only crawl results with meaningful evidence content', async () => {
 		const storage = createStorageMock()
 		vi.stubGlobal(
 			'useStorage',
@@ -113,17 +120,29 @@ describe('crawler/cache', () => {
 		vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
 
 		await setCachedCrawlPages('cache:no-text', [
-			{ url: 'https://example.com/a', excerpt: '   ' }
+			{ url: 'https://example.com/a', excerpt: '   ', fullContent: '' }
 		])
 		expect(storage.setItem).not.toHaveBeenCalled()
 
+		await setCachedCrawlPages('cache:semantic-text', [
+			{ url: 'https://example.com/a', excerpt: '   ', fullContent: '<main>Inhoud</main>' }
+		])
+		expect(storage.setItem).toHaveBeenCalledWith('cache:semantic-text', {
+			expiresAt: 1_700_000_000_000 + CRAWLER_CONFIG.cacheTtlMs,
+			pages: [
+				{ url: 'https://example.com/a', excerpt: '   ', fullContent: '<main>Inhoud</main>' }
+			]
+		})
+
 		await setCachedCrawlPages('cache:with-text', [
-			{ url: 'https://example.com/a', excerpt: 'Inhoud' }
+			{ url: 'https://example.com/a', excerpt: 'Inhoud', fullContent: '<p>Inhoud</p>' }
 		])
 
 		expect(storage.setItem).toHaveBeenCalledWith('cache:with-text', {
 			expiresAt: 1_700_000_000_000 + CRAWLER_CONFIG.cacheTtlMs,
-			pages: [{ url: 'https://example.com/a', excerpt: 'Inhoud' }]
+			pages: [
+				{ url: 'https://example.com/a', excerpt: 'Inhoud', fullContent: '<p>Inhoud</p>' }
+			]
 		})
 	})
 })

--- a/tests/unit/server/utils/crawler/html-error.test.ts
+++ b/tests/unit/server/utils/crawler/html-error.test.ts
@@ -17,6 +17,7 @@ describe('crawler/html parse failures', () => {
 			parseHtmlForCrawl('<html></html>', 'https://example.com', ['example.com'], 120)
 		).toEqual({
 			excerpt: '',
+			fullContent: '',
 			links: []
 		})
 	})

--- a/tests/unit/server/utils/crawler/html-readability.test.ts
+++ b/tests/unit/server/utils/crawler/html-readability.test.ts
@@ -1,0 +1,54 @@
+import { parseHtmlForCrawl } from '~~/server/utils/crawler/html'
+import { describe, expect, it, vi } from 'vitest'
+
+const readabilityParseMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@mozilla/readability', () => ({
+	Readability: class MockReadability {
+		parse() {
+			return readabilityParseMock()
+		}
+	}
+}))
+
+describe('crawler/html readability integration', () => {
+	it('uses readability excerpt + title when readability output is viable', () => {
+		const readableText = 'relevante inhoud '.repeat(40).trim()
+		readabilityParseMock.mockReturnValue({
+			title: 'Readability titel',
+			textContent: readableText,
+			content:
+				'<article class="x"><h2 data-id="a">Kern</h2><p style="color:red">Tekst</p></article>'
+		})
+
+		const result = parseHtmlForCrawl(
+			'<html><head><title>Fallback titel</title></head><body><main>Fallback</main></body></html>',
+			'https://example.com',
+			['example.com'],
+			80
+		)
+
+		expect(result.title).toBe('Readability titel')
+		expect(result.excerpt).toBe(readableText.slice(0, 80).trim())
+		expect(result.fullContent).toBe('<article><h2>Kern</h2><p>Tekst</p></article>')
+	})
+
+	it('falls back to simple extraction when readability output is weak', () => {
+		readabilityParseMock.mockReturnValue({
+			title: 'Readability titel',
+			textContent: 'kort blok'
+		})
+
+		const result = parseHtmlForCrawl(
+			'<html><head><title>Fallback titel</title></head><body><main>Betrouwbare fallback inhoud voor analyse.</main></body></html>',
+			'https://example.com',
+			['example.com'],
+			120
+		)
+
+		expect(result.title).toBe('Fallback titel')
+		expect(result.excerpt).toBe('Betrouwbare fallback inhoud voor analyse.')
+		expect(result.fullContent).toContain('<main>')
+		expect(result.fullContent).toContain('Betrouwbare fallback inhoud voor analyse.')
+	})
+})

--- a/tests/unit/server/utils/crawler/html.test.ts
+++ b/tests/unit/server/utils/crawler/html.test.ts
@@ -9,11 +9,15 @@ describe('crawler/html', () => {
 					<title>  Regionale   Scan  </title>
 				</head>
 				<body>
+					<header class="site-header">Header die niet mee moet</header>
+					<nav class="site-nav"><a href="/menu">Menu</a></nav>
 					<main>
+						<h1 class="headline" data-track="x">Welkom in de regio</h1>
 						Belangrijke introductie tekst.
 						<script>window.shouldNotAppear = true</script>
 						<style>.hidden { display: none; }</style>
 						<a href="/over?utm_source=mail">Over</a>
+						<a href="javascript:alert('xss')">Onveilig</a>
 						<a href="https://sub.example.com/team/">Team</a>
 						<a href="mailto:info@example.com">Mail</a>
 						<a href="#anchor">Anchor</a>
@@ -21,6 +25,7 @@ describe('crawler/html', () => {
 						<a href="https://external.example.org/path">External</a>
 						<a href="https://sub.example.com/team/">Duplicate</a>
 					</main>
+					<footer class="site-footer">Footer die niet mee moet</footer>
 				</body>
 			</html>
 		`
@@ -28,7 +33,14 @@ describe('crawler/html', () => {
 		const result = parseHtmlForCrawl(html, 'https://example.com/start', ['example.com'], 120)
 
 		expect(result.title).toBe('Regionale Scan')
+		expect(result.mainHeading).toBe('Welkom in de regio')
 		expect(result.excerpt).toContain('Belangrijke introductie tekst.')
+		expect(result.fullContent).toContain('<main>')
+		expect(result.fullContent).toContain('<h1>Welkom in de regio</h1>')
+		expect(result.fullContent).not.toContain('site-header')
+		expect(result.fullContent).not.toContain('site-footer')
+		expect(result.fullContent).not.toContain('class=')
+		expect(result.fullContent).not.toContain('javascript:')
 		expect(result.excerpt).not.toContain('window.shouldNotAppear')
 		expect(result.links).toEqual(['https://example.com/over', 'https://sub.example.com/team'])
 	})
@@ -55,6 +67,7 @@ describe('crawler/html', () => {
 		const result = parseHtmlForCrawl('', 'https://example.com', ['example.com'], 50)
 		expect(result).toEqual({
 			excerpt: '',
+			fullContent: '',
 			links: []
 		})
 	})

--- a/tests/unit/server/utils/crawler/website.test.ts
+++ b/tests/unit/server/utils/crawler/website.test.ts
@@ -40,9 +40,9 @@ describe('crawler/website', () => {
 
 	it('returns cached pages when present and truncates to requested max pages', async () => {
 		crawlerDeps.getCachedCrawlPagesMock.mockResolvedValue([
-			{ url: 'https://example.com/1', excerpt: 'one' },
-			{ url: 'https://example.com/2', excerpt: 'two' },
-			{ url: 'https://example.com/3', excerpt: 'three' }
+			{ url: 'https://example.com/1', excerpt: 'one', fullContent: '<p>one</p>' },
+			{ url: 'https://example.com/2', excerpt: 'two', fullContent: '<p>two</p>' },
+			{ url: 'https://example.com/3', excerpt: 'three', fullContent: '<p>three</p>' }
 		])
 
 		const result = await crawlWebsiteForAnalysis({
@@ -53,8 +53,8 @@ describe('crawler/website', () => {
 		})
 
 		expect(result).toEqual([
-			{ url: 'https://example.com/1', excerpt: 'one' },
-			{ url: 'https://example.com/2', excerpt: 'two' }
+			{ url: 'https://example.com/1', excerpt: 'one', fullContent: '<p>one</p>' },
+			{ url: 'https://example.com/2', excerpt: 'two', fullContent: '<p>two</p>' }
 		])
 		expect(crawlerDeps.createCrawlCacheKeyMock).toHaveBeenCalledWith({
 			startUrl: 'https://example.com/start',
@@ -104,6 +104,7 @@ describe('crawler/website', () => {
 			if (html === 'ENTRY') {
 				return {
 					excerpt: 'Inhoud van landing',
+					fullContent: '<article><p>Inhoud van landing</p></article>',
 					links: ['https://example.com/linked']
 				}
 			}
@@ -112,12 +113,14 @@ describe('crawler/website', () => {
 				return {
 					title: 'Sitemap pagina',
 					excerpt: 'Sitemap inhoud',
+					fullContent: '<article><p>Sitemap inhoud</p></article>',
 					links: []
 				}
 			}
 
 			return {
 				excerpt: 'Gekoppelde inhoud',
+				fullContent: '<article><p>Gekoppelde inhoud</p></article>',
 				links: []
 			}
 		})
@@ -130,8 +133,13 @@ describe('crawler/website', () => {
 		})
 
 		expect(result).toEqual([
-			{ url: 'https://example.com/start', excerpt: '' },
-			{ url: 'https://example.com/landing', excerpt: 'Inhoud van landing', title: undefined }
+			{ url: 'https://example.com/start', excerpt: '', fullContent: '' },
+			{
+				url: 'https://example.com/landing',
+				excerpt: 'Inhoud van landing',
+				fullContent: '<article><p>Inhoud van landing</p></article>',
+				title: undefined
+			}
 		])
 		expect(crawlerDeps.fetchSitemapUrlsMock).toHaveBeenCalledWith(
 			'https://example.com/start',
@@ -161,12 +169,14 @@ describe('crawler/website', () => {
 			if (html === 'ENTRY') {
 				return {
 					excerpt: 'Start',
+					fullContent: '<article><p>Start</p></article>',
 					links: ['https://example.com/a', 'https://example.com/a']
 				}
 			}
 
 			return {
 				excerpt: 'Pagina A',
+				fullContent: '<article><p>Pagina A</p></article>',
 				links: []
 			}
 		})
@@ -178,8 +188,18 @@ describe('crawler/website', () => {
 		})
 
 		expect(result).toEqual([
-			{ url: 'https://example.com/start', excerpt: 'Start', title: undefined },
-			{ url: 'https://example.com/a', excerpt: 'Pagina A', title: undefined }
+			{
+				url: 'https://example.com/start',
+				excerpt: 'Start',
+				fullContent: '<article><p>Start</p></article>',
+				title: undefined
+			},
+			{
+				url: 'https://example.com/a',
+				excerpt: 'Pagina A',
+				fullContent: '<article><p>Pagina A</p></article>',
+				title: undefined
+			}
 		])
 		expect(crawlerDeps.fetchHtmlPageMock).toHaveBeenCalledTimes(2)
 		expect(crawlerDeps.fetchHtmlPageMock).toHaveBeenNthCalledWith(
@@ -244,12 +264,14 @@ describe('crawler/website', () => {
 			if (html === 'ENTRY') {
 				return {
 					excerpt: 'Start',
+					fullContent: '<article><p>Start</p></article>',
 					links: ['https://example.com/next']
 				}
 			}
 
 			return {
 				excerpt: 'Volgende pagina',
+				fullContent: '<article><p>Volgende pagina</p></article>',
 				links: []
 			}
 		})
@@ -262,7 +284,12 @@ describe('crawler/website', () => {
 		})
 
 		expect(result).toEqual([
-			{ url: 'https://example.com/start', excerpt: 'Start', title: undefined }
+			{
+				url: 'https://example.com/start',
+				excerpt: 'Start',
+				fullContent: '<article><p>Start</p></article>',
+				title: undefined
+			}
 		])
 		expect(crawlerDeps.fetchHtmlPageMock).toHaveBeenCalledTimes(1)
 	})


### PR DESCRIPTION
Closes #72 

- add readability-first extraction with fallback and semantic full-content evidence
- include compact excerpt + cleaned full content per page in analysis prompt
- improve evidence filtering and cache semantics for excerpt/full-content parity
- harden semantic HTML prompt embedding and safe link retention
- update AI/crawler tests and docs to match the current flow
- replace "uitvoeringsplan eerste 90 dagen" with "voorgesteld stappenplan" in briefing prompt